### PR TITLE
Rename hunter203 to Hunter203

### DIFF
--- a/authentication/config/run.properties
+++ b/authentication/config/run.properties
@@ -1,12 +1,12 @@
 #User list, these will likey match users created by the testdata container
-user.list = root ingest reader icatuser doiminter hunter203
+user.list = root ingest reader icatuser doiminter Hunter203
 
 user.root.password = pw
 user.ingest.password = ingestpw
 user.reader.password = readerpw
 user.icatuser.password = icatuserpw
 user.doiminter.password = polo
-user.hunter203.password = testuser
+user.Hunter203.password = testuser
 
 # user would be returned as "simple/_username_, comment out to return "_username_"
 mechanism = simple


### PR DESCRIPTION
The user generated by the test has the name `Hunter203`, not `hunter203`:
```
+-----+-------------------------+-----------+---------------------+----------------------------+------------+--------------+-----------+--------+---------------------+-----------+---------+
| ID  | AFFILIATION             | CREATE_ID | CREATE_TIME         | EMAIL                      | FAMILYNAME | FULLNAME     | GIVENNAME | MOD_ID | MOD_TIME            | NAME      | ORCIDID |
+-----+-------------------------+-----------+---------------------+----------------------------+------------+--------------+-----------+--------+---------------------+-----------+---------+
| 203 | University Of Cambridge | user      | 2018-08-06 13:42:31 | dbarnes@brooks-johnson.net | NULL       | Tara Navarro | NULL      | user   | 2009-11-24 00:24:33 | Hunter203 | 3010    |
+-----+-------------------------+-----------+---------------------+----------------------------+------------+--------------+-----------+--------+---------------------+-----------+---------+
```

Just looking at this some more, and it seems that the MySql and (by extension) the Python client calls are case insensitive - i.e.
```SQL
SELECT * FROM USER_ WHERE name = 'hunter203';
```
and 
```SQL
SELECT * FROM USER_ WHERE name = 'Hunter203';
```
both return the above. So maybe this is by design - I'll need to look at this some more.