### PR TITLE
Bump to payara7, icat.server6.2 for icat image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           push: true
           context: ./icat
-          tags: ${{ secrets.HARBOR_URL }}/icat_5:latest
+          tags: ${{ secrets.HARBOR_URL }}/icat_6:latest
 
       - name: Build and push testdata
         uses: docker/build-push-action@v5

--- a/icat/Dockerfile
+++ b/icat/Dockerfile
@@ -4,11 +4,10 @@
 # containers. The run.properties contains the name of the auth container which 
 # is needed for icat to connect to the auth service.
 
-# Based on JDK8, also an option for JDK11
-FROM payara/server-full:5.2022.5
+FROM payara/server-full:7.2026.4-jdk25@sha256:1ffb8bdb4e815074f429a0ba8addaacf3b2fd6d3391b984a8695f2c9ac1e70c2
 
 # Define variables to use later on in this dockerfile. 
-ARG ICAT_VERSION=5.0.1
+ARG ICAT_VERSION=6.2.0
 ARG SQL_CONNECTOR_VERSION=mysql-connector-java-8.0.26.jar
 ARG SQL_CONNECTOR_URL=https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.26/$SQL_CONNECTOR_VERSION
 ARG DATASOURCE_CLASSNAME=com.mysql.cj.jdbc.MysqlDataSource
@@ -67,8 +66,8 @@ RUN ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FIL
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} add-library $PAYARA_DIR/glassfish/domains/domain1/lib/ext/$SQL_CONNECTOR_VERSION \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jdbc-connection-pool --ping=true --steadyPoolSize=2 --datasourceClassname=$DATASOURCE_CLASSNAME --resType=javax.sql.DataSource --maxPoolSize=32 icat \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jdbc-resource --connectionpoolid icat jdbc/icat \
-    && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jms-resource --restype javax.jms.Topic jms/ICAT/Topic \
-    && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jms-resource --restype javax.jms.Topic jms/ICAT/log \
+    && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jms-resource --restype jakarta.jms.Topic jms/ICAT/Topic \
+    && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jms-resource --restype jakarta.jms.Topic jms/ICAT/log \
     && ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} 
     
 WORKDIR $HOME_DIR

--- a/icat/config/persistence.xml
+++ b/icat/config/persistence.xml
@@ -5,6 +5,78 @@
 	<persistence-unit name="icat" transaction-type="JTA">
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jta-data-source>jdbc/icat</jta-data-source>
+		<class>org.icatproject.core.entity.Affiliation</class>
+		<class>org.icatproject.core.entity.Application</class>
+		<class>org.icatproject.core.entity.DataCollectionDatafile</class>
+		<class>org.icatproject.core.entity.DataCollectionDataset</class>
+		<class>org.icatproject.core.entity.DataCollectionInvestigation</class>
+		<class>org.icatproject.core.entity.DataCollection</class>
+		<class>org.icatproject.core.entity.DataCollectionParameter</class>
+		<class>org.icatproject.core.entity.DatafileFormat</class>
+		<class>org.icatproject.core.entity.Datafile</class>
+		<class>org.icatproject.core.entity.DatafileParameter</class>
+		<class>org.icatproject.core.entity.DataPublicationDate</class>
+		<class>org.icatproject.core.entity.DataPublicationFunding</class>
+		<class>org.icatproject.core.entity.DataPublication</class>
+		<class>org.icatproject.core.entity.DataPublicationType</class>
+		<class>org.icatproject.core.entity.DataPublicationUser</class>
+		<class>org.icatproject.core.entity.DatasetInstrument</class>
+		<class>org.icatproject.core.entity.Dataset</class>
+		<class>org.icatproject.core.entity.DatasetParameter</class>
+		<class>org.icatproject.core.entity.DatasetTechnique</class>
+		<class>org.icatproject.core.entity.DatasetType</class>
+		<class>org.icatproject.core.entity.FacilityCycle</class>
+		<class>org.icatproject.core.entity.Facility</class>
+		<class>org.icatproject.core.entity.FundingReference</class>
+		<class>org.icatproject.core.entity.Grouping</class>
+		<class>org.icatproject.core.entity.Instrument</class>
+		<class>org.icatproject.core.entity.InstrumentScientist</class>
+		<class>org.icatproject.core.entity.InvestigationFacilityCycle</class>
+		<class>org.icatproject.core.entity.InvestigationFunding</class>
+		<class>org.icatproject.core.entity.InvestigationGroup</class>
+		<class>org.icatproject.core.entity.InvestigationInstrument</class>
+		<class>org.icatproject.core.entity.Investigation</class>
+		<class>org.icatproject.core.entity.InvestigationParameter</class>
+		<class>org.icatproject.core.entity.InvestigationType</class>
+		<class>org.icatproject.core.entity.InvestigationUser</class>
+		<class>org.icatproject.core.entity.Job</class>
+		<class>org.icatproject.core.entity.Keyword</class>
+		<class>org.icatproject.core.entity.Parameter</class>
+		<class>org.icatproject.core.entity.ParameterType</class>
+		<class>org.icatproject.core.entity.PermissibleStringValue</class>
+		<class>org.icatproject.core.entity.Publication</class>
+		<class>org.icatproject.core.entity.PublicStep</class>
+		<class>org.icatproject.core.entity.RelatedDatafile</class>
+		<class>org.icatproject.core.entity.RelatedItem</class>
+		<class>org.icatproject.core.entity.Rule</class>
+		<class>org.icatproject.core.entity.Sample</class>
+		<class>org.icatproject.core.entity.SampleParameter</class>
+		<class>org.icatproject.core.entity.SampleType</class>
+		<class>org.icatproject.core.entity.Shift</class>
+		<class>org.icatproject.core.entity.StudyInvestigation</class>
+		<class>org.icatproject.core.entity.Study</class>
+		<class>org.icatproject.core.entity.Subject</class>
+		<class>org.icatproject.core.entity.Technique</class>
+		<class>org.icatproject.core.entity.UserGroup</class>
+		<class>org.icatproject.core.entity.User</class>
+		<exclude-unlisted-classes />
+		<properties>
+			<property name="eclipselink.cache.shared.default" value="false"/>
+			<property name="eclipselink.logging.level" value="OFF"/>
+			<property name="eclipselink.logging.level.sql" value="OFF"/>
+			<property name="eclipselink.logging.parameters" value="false"/>
+			<property name="eclipselink.ddl-generation" value="create-tables"/>
+			<property name="eclipselink.ddl-generation.output_mode" value="both"/>
+			<property name="eclipselink.deploy-on-startup" value="true"/>
+			<property name="eclipselink.target-server" value="Glassfish"/>
+			<property name="eclipselink.target-database" value="MySQL"/>
+		</properties>
+	</persistence-unit>
+	<persistence-unit name="session" transaction-type="JTA">
+		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+		<jta-data-source>jdbc/icat</jta-data-source>
+		<class>org.icatproject.core.entity.Session</class>
+		<exclude-unlisted-classes />
 		<properties>
 			<property name="eclipselink.cache.shared.default" value="false"/>
 			<property name="eclipselink.logging.level" value="OFF"/>


### PR DESCRIPTION
Bump to latest version of Payara and ICAT.

This is needed for the DOI API, where changes to the schema for DataPublication in ICAT 6.2 (https://github.com/icatproject/icat.server/pull/366) will have implications on how we create subjects.

* Bump versions
* Rename `javax` to `jakarta` (caused by https://github.com/icatproject/icat.server/pull/312)
* Add second `persistence-unit` for sessions (caused by https://github.com/icatproject/icat.server/pull/375)