### PR TITLE
replace invalid args mappings with build-args in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           push: true
           context: ./authentication
-          args:
-            AUTH_TYPE: simple
-            AUTH_VERSION: 2.0.1
+          build-args: |
+            AUTH_TYPE=simple
+            AUTH_VERSION=2.0.1
           tags: ${{ secrets.HARBOR_URL }}/icat_auth_simple:latest
 
       - name: Build and push anon authenticator
@@ -34,9 +34,9 @@ jobs:
         with:
           push: true
           context: ./authentication
-          args:
-            AUTH_TYPE: anon
-            AUTH_VERSION: 2.0.1
+          build-args: |
+            AUTH_TYPE=anon
+            AUTH_VERSION=2.0.1
           tags: ${{ secrets.HARBOR_URL }}/icat_auth_anon:latest
 
       - name: Build and push icat


### PR DESCRIPTION
Fix CI workflow validation errors by using the correct build-args format for Docker image builds.
https://github.com/docker/build-push-action/issues/380#issuecomment-855477968